### PR TITLE
Modifying the chain0.xml files to match the range & position transformation of joints in the original urdf/mjcf files

### DIFF
--- a/assets/actuator0.xml
+++ b/assets/actuator0.xml
@@ -13,7 +13,7 @@
         <position name="panda0_joint3" joint="panda0_joint3" class="panda" kp="870" forcerange="-87 87" ctrlrange="-2.9671 2.9671"/> <!-- velocity="2.1750" -->
         <position name="panda0_joint4" joint="panda0_joint4" class="panda" kp="870" forcerange="-87 87" ctrlrange="-3.1416 0.0"/> <!-- velocity="2.1750" -->
         <position name="panda0_joint5" joint="panda0_joint5" class="panda" kp="120" forcerange="-12 12" ctrlrange="-2.9671 2.9671"/> <!-- velocity="2.6100" -->
-        <position name="panda0_joint6" joint="panda0_joint6" class="panda" kp="120" forcerange="-12 12" ctrlrange="-1.66 2.1817"/> <!-- velocity="2.6100" -->
+        <position name="panda0_joint6" joint="panda0_joint6" class="panda" kp="120" forcerange="-12 12" ctrlrange="-0.0175 3.7525"/> <!-- velocity="2.6100" -->
         <position name="panda0_joint7" joint="panda0_joint7" class="panda" kp="120" forcerange="-12 12" ctrlrange="-2.9671 2.9671"/> <!-- velocity="2.9671" -->
     </actuator>
 </mujocoinclude>

--- a/assets/chain0.xml
+++ b/assets/chain0.xml
@@ -26,7 +26,7 @@
                     <geom class="panda_grey_viz" mesh="link3_dark_viz" pos="0 .001 0"/>
                     <geom class="panda_col" mesh="link3_col" mass="2.04104"/>
                     <body name="panda0_link4" pos="0.0825 0 0" quat="0.707107 0.707107 0 0">
-                        <joint name="panda0_joint4" range="-3.0718 -0.4" class="panda_arm"/>
+                        <joint name="panda0_joint4" range="-3.0718 -0.0698" class="panda_arm"/>
                         <geom class="panda_viz" mesh="link4_viz"/>
                         <geom class="panda_grey_viz" mesh="link4_dark_viz"/>
                         <geom class="panda_col" mesh="link4_col" mass="2.08129"/>
@@ -35,16 +35,18 @@
                             <geom class="panda_viz" mesh="link5_viz"/>
                             <geom class="panda_grey_viz" mesh="link5_dark_viz"/>
                             <geom class="panda_col" mesh="link5_col" mass="3.00049"/>
-                            <body name="panda0_link6" pos="0 0 0" euler='1.57 0 1.57'>
-                                <joint name="panda0_joint6" range="-1.6573 2.1127" class="panda_forearm"/>
+                            <body name="panda0_link6" pos="0 0 0" euler='1.57079 0 0'>
+                            <!-- body name="panda0_link6" pos="0 0 0" euler='1.57 0 1.57' -->
+                                <joint name="panda0_joint6" range="-0.0175 3.7525" class="panda_forearm"/>
+                                <!-- joint name="panda0_joint6" range="-1.6573 2.1127" class="panda_forearm"/ -->
                                 <!-- <body name="panda0_link6" pos="0 0 0" quat="0.707107 0.707107 0 0"> -->
                                 <!-- <joint name="panda0_joint6" range="-0.0873 3.8223" class="panda_forearm"/> -->
                                 <geom class="panda_viz" mesh="link6_viz"/>
                                 <geom class="panda_grey_viz" mesh="link6_dark_viz"/>
                                 <geom class="panda_col" mesh="link6_col" mass="1.3235"/>
-                                <body name="panda0_link7" pos="0.088 0 0" euler='1.57 0 0.7854'>
-                                    <joint name="panda0_joint7" range="-2.8973 2.8973" class="panda_forearm"/>
-                                    <!-- <body name="panda0_link7" pos="0.088 0 0" quat="0.707107 0.707107 0 0"> -->
+                                <!-- <body name="panda0_link7" pos="0.088 0 0" euler='1.57 0 0.7854'> -->
+                                <body name="panda0_link7" pos="0.088 0 0" quat="0.707107 0.707107 0 0">
+                                    <joint name="panda0_joint7" range="-2.8973 2.8973" class="panda_forearm"/> 
                                     <!-- <joint name="panda0_joint7" range="-2.9671 2.9671" class="panda_forearm"/> -->
                                     <geom class="panda_viz" mesh="link7_viz" rgba=".8 .8 .82 1"/>
                                     <geom class="panda_grey_viz" mesh="link7_dark_viz" pos="0 0 -.0008"/>


### PR DESCRIPTION
Fixes #2 

Upon closer inspection of `chain0.xml` (and `actuator0.xml`) It seems like the rotation values for `panda_link6` and `panda_link7` does not match the official urdf in [franka_description](https://github.com/frankaemika/franka_ros/blob/c11f000c2737acc22ed8dfeff40555b2644a4294/franka_description/robots/common/franka_arm.xacro#L107) nor the mjcf file used in [polymetis](https://github.com/facebookresearch/fairo/blob/0a01a7fa7a7c65b2f9a3aebf5e79040940daf9d2/polymetis/polymetis/data/franka_panda/panda_arm.mjcf#L41) (which is the backend used in Robohive).

Maybe related to this offshoot, but the `range` values in the `panda_joint6` and `panda_joint4` is also off from the above two urdf/mjcf, and also the [datasheet values in the franka handbook](https://www.generationrobots.com/media/franka-emika-robot-handbook.pdf) (page 34). For `panda_joint6` the values are off enough that I think `actuator0.xml` also need to be modified. 

The `actuator0.xml`s, `ctrlrange` values seems to be about 2-4% wider than the `range` value in `chain0.xml`. This PR does not set the `ctrlrange` of the modified `panda_joint6` range with those additional 2-4% `ctrlrange` but set the same values. Is there a reason for this extra width in the `ctrlrange` that should be added?

Edit: Those changes might make some upstream code incompatible, especially if data have been collected with non-normalized joint-values + image data  (such as in Robohive) and maybe needs to be considered before merging 